### PR TITLE
CC-407/bugfix: play icon disappearing on android devices

### DIFF
--- a/app/assets/javascripts/custom_play_button.js
+++ b/app/assets/javascripts/custom_play_button.js
@@ -24,6 +24,9 @@ $(document).ready(function() {
         $(this).prop("controls", true);
         $(this).prop("controlsList", "nodownload");
       });
+    } else {
+      $(".play-button").show();
+      $(this).prop("controls", false);
     }
   }
 

--- a/app/assets/javascripts/custom_play_button.js
+++ b/app/assets/javascripts/custom_play_button.js
@@ -1,23 +1,31 @@
 $(document).ready(function() {
-  if (Modernizr.touch && !Foundation.MediaQuery.atLeast('large')) {
-    $('.play-button').hide();
-    $('video').each(function() {
-      $(this).prop('controls', true);
-      $(this).prop('controlsList', 'nodownload');
-    });
-  }
+  adjustVideoControlsToScreenSize();
 
-  $('video').click(function(e) {
-    if ($('.play-button').length) {
+  $(window).resize(function() {
+    adjustVideoControlsToScreenSize();
+  });
+
+  $("video").click(function(e) {
+    if ($(".play-button").length) {
       e.preventDefault();
       videoResponse(this);
     }
   });
 
-  $('.play-button').click(function(e) {
+  $(".play-button").click(function(e) {
     e.preventDefault();
     videoResponse(this.nextElementSibling);
   });
+
+  function adjustVideoControlsToScreenSize() {
+    if (Modernizr.touch && !Foundation.MediaQuery.atLeast("large")) {
+      $(".play-button").hide();
+      $("video").each(function() {
+        $(this).prop("controls", true);
+        $(this).prop("controlsList", "nodownload");
+      });
+    }
+  }
 
   function videoResponse(video) {
     video.paused == true ? playVideo(video) : pauseVideo(video);
@@ -25,17 +33,27 @@ $(document).ready(function() {
 
   function playVideo(video) {
     pauseOtherVideos(video);
-    $(video).closest('.video-container').children('.play-button').css('opacity', '0');
-    $(video).get(0).play();
+    $(video)
+      .closest(".video-container")
+      .children(".play-button")
+      .css("opacity", "0");
+    $(video)
+      .get(0)
+      .play();
   }
 
   function pauseVideo(video) {
-    $(video).closest('.video-container').children('.play-button').css('opacity', '0');
-    $(video).get(0).pause();
+    $(video)
+      .closest(".video-container")
+      .children(".play-button")
+      .css("opacity", "0");
+    $(video)
+      .get(0)
+      .pause();
   }
 
   function pauseOtherVideos(currentVideo) {
-    $('video').each(function() {
+    $("video").each(function() {
       if (this != currentVideo) {
         pauseVideo(this);
       }

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -7,9 +7,13 @@
   padding: 0;
 
   &:hover {
-    .text-container { color: $med-grey; }
+    .text-container {
+      color: $med-grey;
+    }
 
-    .icon-container { background: $med-grey; }
+    .icon-container {
+      background: $med-grey;
+    }
   }
 
   .icon-container {
@@ -48,7 +52,9 @@
 }
 
 .play_video_button {
-  &:hover { color: $white; }
+  &:hover {
+    color: $white;
+  }
 
   i {
     font-size: 22px;
@@ -82,10 +88,13 @@ a {
   }
 }
 
+.orange_submit_button {
+  padding: 5px;
+}
 
-.orange_submit_button { padding: 5px; }
-
-.translation_button { @extend .play_video_button; }
+.translation_button {
+  @extend .play_video_button;
+}
 
 .buttons-container {
   bottom: 0;
@@ -118,18 +127,4 @@ a {
   display: flex;
   height: 1.5rem;
   margin-left: 0;
-}
-
-// Browser specific styles ( Firefox IE 11 and Safari ) to hide the default videojs BigPlayButton
-// User expects to view video without any obsufication and the default button was obsuring the video
-.video-js {
-  &.vjs-big-play-button {
-    display: none;
-  }
-}
-
-// Browser specific style for Chrome to hide the default videojs BigPlayButton
-// User expects to view video without any obsufication and the default button was obsuring the video
-video::-webkit-media-controls-overlay-play-button { // sass-lint:disable-line  no-vendor-prefixes
-  display: none;
 }

--- a/app/assets/stylesheets/_video.scss
+++ b/app/assets/stylesheets/_video.scss
@@ -35,3 +35,10 @@ video {
     display: block;
   }
 }
+
+// Hides the default videojs BigPlayButton because we have our own custom one
+.video-js {
+  &.vjs-big-play-button {
+    display: none;
+  }
+}


### PR DESCRIPTION
This PR responds to:
CC-407 https://rabidtech.atlassian.net/browse/CC-407
Zendesk ticket #798 https://ackama.zendesk.com/agent/tickets/798

The issue: NZSL had reports from Android users that the ‘play’ button has disappeared from the videos in both the search results and the sign pages when viewed on a mobile phone. The video still works when you click on it, but users don’t know to click on the video when there is no play button.

This only affects the responsive view of the website on Android (i.e. the full website view, Android mobile app and iOS mobile app are all fine)

There was a line in buttons.scss that was disabling the play button explicitly for the above use case. This has been removed. I also moved the logic pertaining to play icons in this file into _videos.scss as Elspeth and I agreed that this was more logical.

In addition, I have refactored the logic for custom play buttons so that it responds to a screen resizing event listener as well as on page load.

I have tested this fix using Browserstack on both android and iOs devices (new and old) without issues. Screenshot here showing android play icon displaying correctly:

![Screen Shot 2019-03-26 at 11 27 50 AM](https://user-images.githubusercontent.com/10970711/54963418-a06e8b80-4fcd-11e9-9e8c-47dcbd8d2402.png)
